### PR TITLE
Add category carousel to blog index

### DIFF
--- a/egohygiene.io/src/components/CategoryCarousel.astro
+++ b/egohygiene.io/src/components/CategoryCarousel.astro
@@ -1,0 +1,86 @@
+---
+import type { CategoryGroup } from '../data/categories';
+const { groups } = Astro.props as { groups: CategoryGroup[] };
+---
+<div class="categories" id="category-carousel">
+  {groups.map((group) => (
+    <section class="group" data-group={group.group}>
+      <h3>{group.group}</h3>
+      <div class="carousel">
+        {group.categories.map((cat) => (
+          <a class="card" href={`/blogs/categories/${cat.slug}/`} style={`background-image:url('${cat.image}');`}>
+            <span>{cat.name}</span>
+          </a>
+        ))}
+      </div>
+    </section>
+  ))}
+</div>
+
+<style>
+  .categories {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+    opacity: 0;
+    transform: translateY(20px);
+    transition: opacity 0.6s ease, transform 0.6s ease;
+  }
+  .categories.visible {
+    opacity: 1;
+    transform: none;
+  }
+  .group h3 {
+    margin: 0 0 0.5rem 0;
+  }
+  .carousel {
+    display: flex;
+    overflow-x: auto;
+    gap: 1rem;
+    scroll-snap-type: x mandatory;
+    padding-bottom: 0.5rem;
+  }
+  .card {
+    position: relative;
+    flex: 0 0 auto;
+    width: 180px;
+    height: 100px;
+    border-radius: 12px;
+    overflow: hidden;
+    background-size: cover;
+    background-position: center;
+    color: white;
+    text-decoration: none;
+    scroll-snap-align: start;
+  }
+  .card::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    background: rgba(0,0,0,0.3);
+    transition: background 0.3s ease;
+  }
+  .card:hover::before {
+    background: rgba(0,0,0,0.5);
+  }
+  .card span {
+    position: absolute;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    padding: 0.5rem;
+    font-weight: 700;
+  }
+</style>
+
+<script>
+  const el = document.getElementById('category-carousel');
+  if (el) {
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((e) => {
+        if (e.isIntersecting) el.classList.add('visible');
+      });
+    }, { threshold: 0.1 });
+    observer.observe(el);
+  }
+</script>

--- a/egohygiene.io/src/data/categories.ts
+++ b/egohygiene.io/src/data/categories.ts
@@ -1,0 +1,89 @@
+export interface Category {
+  name: string;
+  slug: string;
+  image: string;
+}
+
+export interface CategoryGroup {
+  group: string;
+  categories: Category[];
+}
+
+const makeSlug = (name: string) => name.toLowerCase().replace(/\s+/g, '-');
+
+export const CATEGORY_GROUPS: CategoryGroup[] = [
+  {
+    group: 'Mental & Cognitive',
+    categories: [
+      'psychology',
+      'neurology',
+      'cognitive science',
+      'behavioral science',
+      'identity',
+      'habit formation',
+      'self-discipline',
+    ].map((name) => ({
+      name,
+      slug: makeSlug(name),
+      image: `/assets/categories/${makeSlug(name)}.jpg`,
+    })),
+  },
+  {
+    group: 'Spiritual & Transpersonal',
+    categories: [
+      'spirituality',
+      'metaphysics',
+      'consciousness studies',
+      'shadow work',
+      'archetypes',
+      'ritual',
+      'alchemy',
+      'dreamwork',
+    ].map((name) => ({
+      name,
+      slug: makeSlug(name),
+      image: `/assets/categories/${makeSlug(name)}.jpg`,
+    })),
+  },
+  {
+    group: 'Body & Embodiment',
+    categories: [
+      'meditation',
+      'breathwork',
+      'somatics',
+      'healing',
+    ].map((name) => ({
+      name,
+      slug: makeSlug(name),
+      image: `/assets/categories/${makeSlug(name)}.jpg`,
+    })),
+  },
+  {
+    group: 'Philosophical & Reflective',
+    categories: [
+      'philosophy',
+      'existentialism',
+      'ethics',
+      'symbolism',
+      'journaling',
+      'downloads',
+      'synapse',
+    ].map((name) => ({
+      name,
+      slug: makeSlug(name),
+      image: `/assets/categories/${makeSlug(name)}.jpg`,
+    })),
+  },
+  {
+    group: 'Systems & External',
+    categories: [
+      'systems thinking',
+      'technology',
+      'information theory',
+    ].map((name) => ({
+      name,
+      slug: makeSlug(name),
+      image: `/assets/categories/${makeSlug(name)}.jpg`,
+    })),
+  },
+];

--- a/egohygiene.io/src/pages/blogs/index.astro
+++ b/egohygiene.io/src/pages/blogs/index.astro
@@ -6,6 +6,8 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../../consts';
 import { getCollection } from 'astro:content';
 import FormattedDate from '../../components/FormattedDate.astro';
 import { Image } from 'astro:assets';
+import CategoryCarousel from '../../components/CategoryCarousel.astro';
+import { CATEGORY_GROUPS } from '../../data/categories';
 
 const posts = (await getCollection('blog')).sort(
   (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
@@ -89,6 +91,7 @@ const posts = (await getCollection('blog')).sort(
   <body>
     <Header />
     <main>
+      <CategoryCarousel groups={CATEGORY_GROUPS} />
       <section>
         <ul>
           {


### PR DESCRIPTION
## Summary
- define blog category groups with slug and image path
- add a CategoryCarousel component that displays category cards with fade-in on scroll
- show CategoryCarousel on the blog landing page

## Testing
- `npm run build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b2acf1ed0832cb554e0d5297a030f