### PR TITLE
Add animated landing page components

### DIFF
--- a/egohygiene.io/src/components/landing/CategoryCarousel.astro
+++ b/egohygiene.io/src/components/landing/CategoryCarousel.astro
@@ -1,0 +1,41 @@
+---
+const categories = [
+  'psychology',
+  'metaphysics',
+  'meditation',
+  'systems thinking',
+  'dreamwork',
+  'technology',
+  'alchemic rituals'
+];
+---
+<div id="landing-carousel" class="overflow-x-auto py-8" data-animate>
+  <div class="flex gap-4 px-4 min-w-max motion-safe:opacity-0 motion-safe:translate-y-6 transition-all duration-700">
+    {categories.map(cat => (
+      <div class="flex-shrink-0 w-48 h-28 rounded-lg bg-gray-200 dark:bg-gray-700 overflow-hidden relative shadow-lg" style={`background-image:url('/assets/categories/${cat.replace(/\s+/g,'-')}.jpg'); background-size:cover; background-position:center;`}>
+        <div class="absolute inset-0 bg-black/30 flex items-end">
+          <span class="text-white text-sm p-2">{cat}</span>
+        </div>
+      </div>
+    ))}
+  </div>
+</div>
+
+<style>
+#landing-carousel[data-visible] .motion-safe\:opacity-0{
+  opacity:1;transform:none;
+}
+#landing-carousel .motion-safe\:opacity-0{
+  opacity:0;transform:translateY(1.5rem);
+}
+</style>
+
+<script>
+const car = document.getElementById('landing-carousel');
+if(car){
+  const obs = new IntersectionObserver((entries)=>{
+    entries.forEach(e=>{if(e.isIntersecting) car.setAttribute('data-visible','');});
+  },{threshold:0.2});
+  obs.observe(car);
+}
+</script>

--- a/egohygiene.io/src/components/landing/IntroSection.astro
+++ b/egohygiene.io/src/components/landing/IntroSection.astro
@@ -1,0 +1,25 @@
+---
+---
+<section id="intro" class="py-16 bg-white dark:bg-gray-900" data-animate>
+  <div class="container mx-auto px-4 max-w-3xl text-center motion-safe:opacity-0 motion-safe:translate-y-6 transition-all duration-700">
+    <h2 class="text-3xl font-semibold text-gray-900 dark:text-gray-100 mb-4">What is Ego Hygiene?</h2>
+    <p class="text-gray-700 dark:text-gray-300">
+      Ego Hygiene explores mindful practices that harmonize the rational and the mystical. Through reflective technology and spiritual self-care, we nurture clarity, compassion, and creativity.
+    </p>
+  </div>
+</section>
+
+<style>
+#intro[data-visible] .motion-safe\:opacity-0{opacity:1;transform:none;}
+#intro .motion-safe\:opacity-0{opacity:0;transform:translateY(1.5rem);}
+</style>
+
+<script>
+const section = document.getElementById('intro');
+if(section){
+  const obs = new IntersectionObserver((entries)=>{
+    entries.forEach(e=>{if(e.isIntersecting) section.setAttribute('data-visible','');});
+  },{threshold:0.3});
+  obs.observe(section);
+}
+</script>

--- a/egohygiene.io/src/components/landing/LandingHero.astro
+++ b/egohygiene.io/src/components/landing/LandingHero.astro
@@ -1,0 +1,30 @@
+---
+---
+<section id="landing-hero" class="min-h-[60vh] flex flex-col justify-center items-center text-center bg-gradient-to-b from-white via-teal-50 to-indigo-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 py-20">
+  <div class="container mx-auto px-4 motion-safe:opacity-0 motion-safe:translate-y-6 transition-all duration-700" data-animate>
+    <h1 class="text-5xl font-semibold text-gray-900 dark:text-gray-100 mb-4 font-sans">Ego Hygiene</h1>
+    <p class="text-lg text-gray-700 dark:text-gray-300 mb-8 max-w-2xl mx-auto">
+      Cultivating balance between spiritual insight and technical mastery.
+    </p>
+    <a href="/blogs" class="inline-block bg-indigo-600 text-white rounded-full px-6 py-3 shadow-lg hover:bg-indigo-700 transition-colors">Explore the Blog</a>
+  </div>
+</section>
+
+<style>
+#landing-hero[data-visible] [data-animate]{
+  opacity:1;transform:none;
+}
+#landing-hero [data-animate]{
+  opacity:0;transform:translateY(1.5rem);
+}
+</style>
+
+<script>
+const hero = document.getElementById('landing-hero');
+if(hero){
+  const obs=new IntersectionObserver((e)=>{
+    e.forEach(ent=>{if(ent.isIntersecting){hero.setAttribute('data-visible','');}});
+  },{threshold:0.3});
+  obs.observe(hero);
+}
+</script>

--- a/egohygiene.io/src/components/landing/LandingPage.astro
+++ b/egohygiene.io/src/components/landing/LandingPage.astro
@@ -1,0 +1,8 @@
+---
+import LandingHero from './LandingHero.astro';
+import CategoryCarousel from './CategoryCarousel.astro';
+import IntroSection from './IntroSection.astro';
+---
+<LandingHero />
+<CategoryCarousel />
+<IntroSection />

--- a/egohygiene.io/src/pages/index.astro
+++ b/egohygiene.io/src/pages/index.astro
@@ -3,6 +3,7 @@ import BaseHead from '../components/BaseHead.astro';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
+import LandingPage from '../components/landing/LandingPage.astro';
 ---
 
 <!doctype html>
@@ -10,11 +11,10 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
   <head>
     <BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
   </head>
-  <body>
+  <body class="bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
     <Header />
     <main>
-      <h1>Welcome to {SITE_TITLE}</h1>
-      <p><a href="/blogs">Go to the Blog</a></p>
+      <LandingPage />
     </main>
     <Footer />
   </body>


### PR DESCRIPTION
## Summary
- add hero, intro, carousel, and wrapper components
- compose landing page at `/` using new components
- style components with Tailwind-like utility classes
- add simple fade-in animations via intersection observer

## Testing
- `pnpm build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b396d9510832c9f034e2cb3d1b0fe