### PR TITLE
Add TypeScript models and sample data

### DIFF
--- a/src/data/pillars.json
+++ b/src/data/pillars.json
@@ -1,0 +1,14 @@
+[
+  {
+    "id": 1,
+    "slug": "self-awareness",
+    "title": "Self Awareness",
+    "subtitle": "Know Thyself",
+    "description": "Understanding of personal strengths and weaknesses.",
+    "domains": ["mind", "body"],
+    "aspects": ["growth", "reflection"],
+    "tags": ["introspection", "mindfulness"],
+    "quote": "To know yourself is the beginning of wisdom.",
+    "image": "/images/pillars/self-awareness.jpg"
+  }
+]

--- a/src/data/relationships.json
+++ b/src/data/relationships.json
@@ -1,0 +1,8 @@
+[
+  {
+    "from": "synapse:gratitude-practice",
+    "to": "pillar:self-awareness",
+    "type": "belongs_to",
+    "description": "This synapse is part of the self-awareness pillar"
+  }
+]

--- a/src/data/synapses.json
+++ b/src/data/synapses.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "1",
+    "slug": "gratitude-practice",
+    "title": "Gratitude Practice",
+    "content": "Write down things you are grateful for.",
+    "tags": ["mindfulness"],
+    "pillar": "self-awareness",
+    "created": "2024-01-01T00:00:00Z",
+    "updated": "2024-01-02T00:00:00Z"
+  }
+]

--- a/src/data/systems.json
+++ b/src/data/systems.json
@@ -1,0 +1,8 @@
+[
+  {
+    "name": "morning routine",
+    "description": "A set of actions to start the day",
+    "pillar": "self-awareness",
+    "components": ["meditation", "exercise"]
+  }
+]

--- a/src/data/tags.json
+++ b/src/data/tags.json
@@ -1,0 +1,7 @@
+[
+  {
+    "name": "mindfulness",
+    "description": "Being fully present",
+    "related": ["self-awareness"]
+  }
+]

--- a/src/models/Pillar.ts
+++ b/src/models/Pillar.ts
@@ -1,0 +1,25 @@
+import pillars from '../data/pillars.json';
+
+export interface Pillar {
+  id: number;
+  slug: string;
+  title: string;
+  subtitle: string;
+  description: string;
+  domains: string[];
+  aspects: string[];
+  tags: string[];
+  quote: string;
+  image?: string;
+}
+
+export function loadPillars(): Pillar[] {
+  return pillars as Pillar[];
+}
+
+export function mapPillarsBySlug(): Record<string, Pillar> {
+  return loadPillars().reduce((acc, pillar) => {
+    acc[pillar.slug] = pillar;
+    return acc;
+  }, {} as Record<string, Pillar>);
+}

--- a/src/models/Relationship.ts
+++ b/src/models/Relationship.ts
@@ -1,0 +1,20 @@
+import relationships from '../data/relationships.json';
+
+export interface Relationship {
+  from: string;
+  to: string;
+  type: string;
+  description: string;
+}
+
+export function loadRelationships(): Relationship[] {
+  return relationships as Relationship[];
+}
+
+export function mapRelationshipsByFrom(): Record<string, Relationship[]> {
+  return loadRelationships().reduce((acc, rel) => {
+    if (!acc[rel.from]) acc[rel.from] = [];
+    acc[rel.from].push(rel);
+    return acc;
+  }, {} as Record<string, Relationship[]>);
+}

--- a/src/models/Synapse.ts
+++ b/src/models/Synapse.ts
@@ -1,0 +1,23 @@
+import synapses from '../data/synapses.json';
+
+export interface Synapse {
+  id: string;
+  slug: string;
+  title: string;
+  content: string;
+  tags: string[];
+  pillar: string;
+  created: string; // ISO date-time
+  updated?: string; // ISO date-time
+}
+
+export function loadSynapses(): Synapse[] {
+  return synapses as Synapse[];
+}
+
+export function mapSynapsesBySlug(): Record<string, Synapse> {
+  return loadSynapses().reduce((acc, item) => {
+    acc[item.slug] = item;
+    return acc;
+  }, {} as Record<string, Synapse>);
+}

--- a/src/models/System.ts
+++ b/src/models/System.ts
@@ -1,0 +1,19 @@
+import systems from '../data/systems.json';
+
+export interface System {
+  name: string;
+  description: string;
+  pillar: string;
+  components: string[];
+}
+
+export function loadSystems(): System[] {
+  return systems as System[];
+}
+
+export function mapSystemsByName(): Record<string, System> {
+  return loadSystems().reduce((acc, system) => {
+    acc[system.name] = system;
+    return acc;
+  }, {} as Record<string, System>);
+}

--- a/src/models/Tag.ts
+++ b/src/models/Tag.ts
@@ -1,0 +1,18 @@
+import tags from '../data/tags.json';
+
+export interface Tag {
+  name: string;
+  description: string;
+  related?: string[];
+}
+
+export function loadTags(): Tag[] {
+  return tags as Tag[];
+}
+
+export function mapTagsByName(): Record<string, Tag> {
+  return loadTags().reduce((acc, tag) => {
+    acc[tag.name] = tag;
+    return acc;
+  }, {} as Record<string, Tag>);
+}


### PR DESCRIPTION
## Summary
- generate example JSON data for core entities
- add TypeScript models with loader utilities

## Testing
- `npx tsc --noEmit src/models/*.ts` *(fails: cannot find module '../data/*.json')*

------
https://chatgpt.com/codex/tasks/task_e_687c3438d244832c992939104f24e9c7