### PR TITLE
Display synapse posts on blogs page

### DIFF
--- a/egohygiene.io/src/components/blog/Pagination.astro
+++ b/egohygiene.io/src/components/blog/Pagination.astro
@@ -1,0 +1,24 @@
+---
+const { page, perPage, total } = Astro.props as { page: number; perPage: number; total: number };
+const totalPages = Math.ceil(total / perPage);
+const hasPrev = page > 1;
+const hasNext = page < totalPages;
+---
+<nav class="pagination">
+  {hasPrev && <a href={`?page=${page - 1}`} class="prev">Prev</a>}
+  <span class="info">Page {page} of {totalPages}</span>
+  {hasNext && <a href={`?page=${page + 1}`} class="next">Next</a>}
+</nav>
+
+<style>
+.pagination {
+  display: flex;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 1rem;
+}
+.pagination a {
+  text-decoration: none;
+  color: rgb(var(--accent));
+}
+</style>

--- a/egohygiene.io/src/components/blog/SynapseCard.astro
+++ b/egohygiene.io/src/components/blog/SynapseCard.astro
@@ -1,0 +1,38 @@
+---
+import FormattedDate from '../FormattedDate.astro';
+import type { Synapse } from '../../../../src/models/Synapse';
+
+const { synapse } = Astro.props as { synapse: Synapse };
+---
+<article class="synapse-card">
+  <a href={`/blogs/${synapse.slug}/`} class="block no-underline">
+    <h4 class="title">{synapse.title}</h4>
+    <p class="date"><FormattedDate date={new Date(synapse.created)} /></p>
+    <p class="excerpt">{synapse.content.slice(0, 120)}{synapse.content.length > 120 ? '…' : ''}</p>
+    <p class="tags">{synapse.tags.map(tag => `#${tag}`).join(' ')}</p>
+  </a>
+</article>
+
+<style>
+.synapse-card {
+  padding: 0.5rem;
+}
+.synapse-card .title {
+  margin: 0 0 0.25rem 0;
+  color: rgb(var(--black));
+}
+.synapse-card .date {
+  margin: 0 0 0.5rem 0;
+  color: rgb(var(--gray));
+  font-size: 0.9em;
+}
+.synapse-card .excerpt {
+  margin: 0 0 0.5rem 0;
+  color: rgb(var(--gray-dark));
+}
+.synapse-card .tags {
+  margin: 0;
+  font-size: 0.85em;
+  color: rgb(var(--accent));
+}
+</style>

--- a/egohygiene.io/src/components/blog/SynapseList.astro
+++ b/egohygiene.io/src/components/blog/SynapseList.astro
@@ -1,0 +1,30 @@
+---
+import type { Synapse } from '../../../../src/models/Synapse';
+import SynapseCard from './SynapseCard.astro';
+
+const { synapses } = Astro.props as { synapses: Synapse[] };
+---
+<ul class="synapse-list">
+  {synapses.map((syn) => (
+    <li><SynapseCard synapse={syn} /></li>
+  ))}
+</ul>
+
+<style>
+.synapse-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.synapse-list li {
+  width: calc(50% - 1rem);
+}
+@media (max-width: 720px) {
+  .synapse-list li {
+    width: 100%;
+  }
+}
+</style>

--- a/egohygiene.io/src/pages/blogs/index.astro
+++ b/egohygiene.io/src/pages/blogs/index.astro
@@ -3,15 +3,19 @@ import BaseHead from '../../components/BaseHead.astro';
 import Header from '../../components/Header.astro';
 import Footer from '../../components/Footer.astro';
 import { SITE_TITLE, SITE_DESCRIPTION } from '../../consts';
-import { getCollection } from 'astro:content';
-import FormattedDate from '../../components/FormattedDate.astro';
-import { Image } from 'astro:assets';
+import { getSynapses } from '../../../../src/models/Synapse';
+import SynapseList from '../../components/blog/SynapseList.astro';
+import Pagination from '../../components/blog/Pagination.astro';
 import CategoryCarousel from '../../components/CategoryCarousel.astro';
 import { CATEGORY_GROUPS } from '../../data/categories';
 
-const posts = (await getCollection('blog')).sort(
-  (a, b) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
+const allSynapses = getSynapses().sort(
+  (a, b) => new Date(b.created).valueOf() - new Date(a.created).valueOf(),
 );
+const perPage = 5;
+const currentPage = Number(Astro.url.searchParams.get('page') || '1');
+const start = (currentPage - 1) * perPage;
+const paged = allSynapses.slice(start, start + perPage);
 ---
 
 <!doctype html>
@@ -22,39 +26,6 @@ const posts = (await getCollection('blog')).sort(
       main {
         width: 960px;
       }
-      ul {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 2rem;
-        list-style-type: none;
-        margin: 0;
-        padding: 0;
-      }
-      ul li {
-        width: calc(50% - 1rem);
-      }
-      ul li * {
-        text-decoration: none;
-        transition: 0.2s ease;
-      }
-      ul li:first-child {
-        width: 100%;
-        margin-bottom: 1rem;
-        text-align: center;
-      }
-      ul li:first-child img {
-        width: 100%;
-      }
-      ul li:first-child .title {
-        font-size: 2.369rem;
-      }
-      ul li img {
-        margin-bottom: 0.5rem;
-        border-radius: 12px;
-      }
-      ul li a {
-        display: block;
-      }
       .title {
         margin: 0;
         color: rgb(var(--black));
@@ -64,28 +35,6 @@ const posts = (await getCollection('blog')).sort(
         margin: 0;
         color: rgb(var(--gray));
       }
-      ul li a:hover h4,
-      ul li a:hover .date {
-        color: rgb(var(--accent));
-      }
-      ul a:hover img {
-        box-shadow: var(--box-shadow);
-      }
-      @media (max-width: 720px) {
-        ul {
-          gap: 0.5em;
-        }
-        ul li {
-          width: 100%;
-          text-align: center;
-        }
-        ul li:first-child {
-          margin-bottom: 0;
-        }
-        ul li:first-child .title {
-          font-size: 1.563em;
-        }
-      }
     </style>
   </head>
   <body>
@@ -93,23 +42,8 @@ const posts = (await getCollection('blog')).sort(
     <main>
       <CategoryCarousel groups={CATEGORY_GROUPS} />
       <section>
-        <ul>
-          {
-            posts.map((post) => (
-              <li>
-                <a href={`/blogs/${post.id}/`}>
-                  {post.data.heroImage && (
-                    <Image width={720} height={360} src={post.data.heroImage} alt="" />
-                  )}
-                  <h4 class="title">{post.data.title}</h4>
-                  <p class="date">
-                    <FormattedDate date={post.data.pubDate} />
-                  </p>
-                </a>
-              </li>
-            ))
-          }
-        </ul>
+        <SynapseList synapses={paged} />
+        <Pagination page={currentPage} perPage={perPage} total={allSynapses.length} />
       </section>
     </main>
     <Footer />

--- a/src/models/Synapse.ts
+++ b/src/models/Synapse.ts
@@ -15,6 +15,14 @@ export function loadSynapses(): Synapse[] {
   return synapses as Synapse[];
 }
 
+/**
+ * Historically this loader was exposed as `getSynapses` in various parts of the
+ * codebase. Provide a thin wrapper so both names can be used interchangeably.
+ */
+export function getSynapses(): Synapse[] {
+  return loadSynapses();
+}
+
 export function mapSynapsesBySlug(): Record<string, Synapse> {
   return loadSynapses().reduce((acc, item) => {
     acc[item.slug] = item;


### PR DESCRIPTION
## Summary
- add `getSynapses` wrapper to model loader
- render synapse data with new SynapseCard component
- add SynapseList and Pagination components
- update `/blogs` listing to load JSON data with simple paging

## Testing
- `pnpm build` *(fails: astro not found due to missing deps)*
- `pnpm install` *(fails: registry access forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687c5b934208832c91e754187c9d5247