### PR TITLE
Add hybrid landing page layout

### DIFF
--- a/egohygiene.io/src/components/landing/AboutEgoHygiene.astro
+++ b/egohygiene.io/src/components/landing/AboutEgoHygiene.astro
@@ -1,0 +1,15 @@
+---
+---
+<section id="about" class="relative py-20 bg-gradient-to-b from-white to-gray-50 dark:from-gray-900 dark:to-gray-800">
+  <div class="container mx-auto px-4 max-w-3xl text-center">
+    <h2 class="text-4xl font-bold text-gray-900 dark:text-gray-100 mb-4">About Ego Hygiene</h2>
+    <p class="text-gray-700 dark:text-gray-300">
+      Ego Hygiene explores mindful technologies and spiritual practices that nurture clarity and balance within the ecosystem of self.
+    </p>
+  </div>
+  <div class="absolute bottom-0 left-0 w-full overflow-hidden leading-none" aria-hidden="true">
+    <svg class="relative block w-full h-12" viewBox="0 0 1440 52" preserveAspectRatio="none">
+      <path d="M0,0 C0,0 1440,0 1440,0 L1440,52 L0,52 Z" fill="currentColor" class="text-gray-50 dark:text-gray-800"></path>
+    </svg>
+  </div>
+</section>

--- a/egohygiene.io/src/components/landing/ExplorePillars.astro
+++ b/egohygiene.io/src/components/landing/ExplorePillars.astro
@@ -1,0 +1,19 @@
+---
+import { loadPillars } from '../../../../src/models/Pillar';
+
+const pillars = loadPillars().slice(0, 4);
+---
+<section id="pillars" class="py-16 bg-white dark:bg-gray-900">
+  <div class="container mx-auto px-4">
+    <h2 class="text-3xl font-bold text-center mb-8 text-gray-900 dark:text-gray-100">Explore the Pillars</h2>
+    <div class="grid gap-8 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+      {pillars.map(pillar => (
+        <a href={`/pillars/${pillar.slug}`} class="group block rounded-lg bg-gray-100 dark:bg-gray-800 p-6 hover:bg-indigo-50 dark:hover:bg-gray-700 transition-colors">
+          <h3 class="text-xl font-semibold text-gray-900 dark:text-gray-100 mb-2">{pillar.title}</h3>
+          <p class="text-sm text-gray-600 dark:text-gray-400 mb-4">{pillar.subtitle}</p>
+          <blockquote class="text-gray-500 dark:text-gray-400 italic">{pillar.quote}</blockquote>
+        </a>
+      ))}
+    </div>
+  </div>
+</section>

--- a/egohygiene.io/src/components/landing/Footer.astro
+++ b/egohygiene.io/src/components/landing/Footer.astro
@@ -1,0 +1,20 @@
+---
+const year = new Date().getFullYear();
+---
+<footer class="py-8 bg-gray-100 dark:bg-gray-800 text-center text-sm">
+  <p class="text-gray-600 dark:text-gray-400">&copy; {year} Ego Hygiene</p>
+  <div class="mt-4 flex justify-center gap-6">
+    <a href="/about" class="text-gray-600 dark:text-gray-400 hover:text-indigo-600">About</a>
+    <a href="/blogs" class="text-gray-600 dark:text-gray-400 hover:text-indigo-600">Blog</a>
+    <a href="https://github.com" target="_blank" class="text-gray-600 dark:text-gray-400 hover:text-indigo-600">GitHub</a>
+  </div>
+  <button id="themeToggle" class="mt-6 px-3 py-1 rounded bg-gray-200 dark:bg-gray-700 text-gray-700 dark:text-gray-200">Toggle Theme</button>
+  <script>
+    const btn = document.getElementById('themeToggle');
+    btn?.addEventListener('click', () => {
+      const root = document.documentElement;
+      root.classList.toggle('dark');
+      localStorage.theme = root.classList.contains('dark') ? 'dark' : 'light';
+    });
+  </script>
+</footer>

--- a/egohygiene.io/src/components/landing/LatestSynapses.astro
+++ b/egohygiene.io/src/components/landing/LatestSynapses.astro
@@ -1,0 +1,21 @@
+---
+import { getSynapses } from '../../../../src/models/Synapse';
+import SynapseCard from '../blog/SynapseCard.astro';
+
+const synapses = getSynapses()
+  .sort((a, b) => new Date(b.created).valueOf() - new Date(a.created).valueOf())
+  .slice(0, 4);
+---
+<section id="synapses" class="py-16 bg-gray-50 dark:bg-gray-900">
+  <div class="container mx-auto px-4 max-w-5xl">
+    <h2 class="text-3xl font-bold text-center mb-8 text-gray-900 dark:text-gray-100">Latest Synapses</h2>
+    <div class="grid gap-8 md:grid-cols-2">
+      {synapses.map((syn) => (
+        <SynapseCard synapse={syn} />
+      ))}
+    </div>
+    <div class="text-center mt-8">
+      <a href="/blogs" class="inline-block bg-indigo-600 text-white px-6 py-3 rounded-full hover:bg-indigo-700 transition-colors">View All Posts</a>
+    </div>
+  </div>
+</section>

--- a/egohygiene.io/src/pages/index.astro
+++ b/egohygiene.io/src/pages/index.astro
@@ -1,4 +1,53 @@
 ---
+import BaseHead from '../components/BaseHead.astro';
+import Header from '../components/Header.astro';
 import LandingScene from '../components/3d/LandingScene.jsx';
+import AboutEgoHygiene from '../components/landing/AboutEgoHygiene.astro';
+import LatestSynapses from '../components/landing/LatestSynapses.astro';
+import ExplorePillars from '../components/landing/ExplorePillars.astro';
+import Footer from '../components/landing/Footer.astro';
+import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
 ---
-<LandingScene client:only="react" />
+<!doctype html>
+<html lang="en" class="scroll-smooth">
+  <head>
+    <BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
+    <script src="https://cdn.tailwindcss.com"></script>
+  </head>
+  <body class="bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100">
+    <div id="nav-wrapper" class="fixed top-0 left-0 w-full opacity-0 transition-opacity duration-500 pointer-events-none z-20">
+      <Header />
+    </div>
+    <section id="hero" class="relative h-screen w-screen overflow-hidden">
+      <LandingScene client:only="react" />
+      <div class="absolute inset-0 flex flex-col items-center justify-center text-center pointer-events-none">
+        <h1 class="text-5xl md:text-6xl font-bold text-white drop-shadow-lg">Ego Hygiene</h1>
+        <p class="mt-4 text-xl text-gray-200 max-w-xl">Cultivate clarity through mindful technology and inner exploration.</p>
+        <button id="cta" class="mt-8 px-6 py-3 bg-indigo-600 text-white rounded-full pointer-events-auto hover:bg-indigo-700">Explore the Pillars</button>
+      </div>
+    </section>
+    <AboutEgoHygiene />
+    <LatestSynapses />
+    <ExplorePillars />
+    <Footer />
+    <script>
+      const nav = document.getElementById('nav-wrapper');
+      const hero = document.getElementById('hero');
+      const cta = document.getElementById('cta');
+      const about = document.getElementById('about');
+      window.addEventListener('scroll', () => {
+        if(window.scrollY > hero.offsetHeight - 100){
+          nav.classList.remove('opacity-0','pointer-events-none');
+          nav.classList.add('opacity-100');
+        } else {
+          nav.classList.add('opacity-0','pointer-events-none');
+          nav.classList.remove('opacity-100');
+        }
+      });
+      cta?.addEventListener('click', (e)=>{
+        e.preventDefault();
+        about?.scrollIntoView({ behavior: 'smooth' });
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add new landing components: AboutEgoHygiene, LatestSynapses, ExplorePillars and footer
- rebuild home page with 3D hero and new sections

## Testing
- `npm run build` *(fails: `astro: not found`)*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_687c5f808b78832ca929f32575150858