### PR TITLE
Enhance cosmic visuals for landing scene

### DIFF
--- a/egohygiene.io/src/components/3d/LandingScene.jsx
+++ b/egohygiene.io/src/components/3d/LandingScene.jsx
@@ -1,6 +1,6 @@
 import React, { Suspense } from 'react';
 import { Canvas } from '@react-three/fiber';
-import { OrbitControls, Stars } from '@react-three/drei';
+import { OrbitControls, Stars, Sparkles } from '@react-three/drei';
 import { animated } from '@react-spring/three';
 import pillars from '../../../../src/data/pillars.json';
 import EgoCore from './EgoCore.jsx';
@@ -12,9 +12,11 @@ export default function LandingScene() {
   return (
     <div className="w-screen h-screen relative">
       <Canvas camera={{ position: [0, 0, 10] }}>
-        <color attach="background" args={[ '#050505' ]} />
+        <color attach="background" args={[ '#000000' ]} />
         <ambientLight intensity={0.5} />
-        <Stars />
+        <pointLight position={[10, 10, 10]} intensity={1.2} />
+        <Stars radius={100} depth={50} count={5000} factor={4} saturation={0} fade speed={1} />
+        <Sparkles count={1000} scale={[100, 100, 100]} size={1} speed={0.5} color="white" />
         <Suspense fallback={null}>
           <EgoCore />
           {pillars.map((pillar, i) => (

--- a/egohygiene.io/src/components/3d/Planet.jsx
+++ b/egohygiene.io/src/components/3d/Planet.jsx
@@ -34,7 +34,13 @@ export default function Planet({ pillar, index, total }) {
         onPointerOut={() => setHovered(false)}
       >
         <sphereGeometry args={[0.5, 32, 32]} />
-        <meshStandardMaterial color={colors[index % colors.length]} />
+        <meshStandardMaterial
+          color={colors[index % colors.length]}
+          emissive={colors[index % colors.length]}
+          emissiveIntensity={0.2}
+          roughness={0.3}
+          metalness={0.1}
+        />
       </animated.mesh>
       <Text position={[0, 0.8, 0]} fontSize={0.3} color="white" anchorX="center" anchorY="middle">
         {pillar.title}


### PR DESCRIPTION
## Summary
- add sparkles and deeper star field to landing scene
- add subtle point light and improved space background
- give planets subtle emission and material tweaks for a more realistic look

## Testing
- `npm run build` *(fails: `astro` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c6111186c832cae3ef9cf15fdf1b9