### PR TITLE
Add glossary terms page

### DIFF
--- a/egohygiene.io/src/components/Header.astro
+++ b/egohygiene.io/src/components/Header.astro
@@ -9,7 +9,8 @@ import { SITE_TITLE } from '../consts';
 		<div class="internal-links">
 			<HeaderLink href="/">Home</HeaderLink>
                         <HeaderLink href="/synapses">Synapses</HeaderLink>
-			<HeaderLink href="/about">About</HeaderLink>
+                        <HeaderLink href="/terms">Terms</HeaderLink>
+                        <HeaderLink href="/about">About</HeaderLink>
 		</div>
 		<div class="social-links">
 			<a href="https://m.webtoo.ls/@astro" target="_blank">

--- a/egohygiene.io/src/components/term/TermCard.astro
+++ b/egohygiene.io/src/components/term/TermCard.astro
@@ -1,0 +1,29 @@
+---
+import type { Term } from '../../../../src/models/Term';
+const { term } = Astro.props as { term: Term };
+---
+<article class="term-card">
+  <h4 class="name">{term.term}</h4>
+  <p class="definition">{term.definition}</p>
+</article>
+
+<style>
+.term-card {
+  display: flex;
+  flex-direction: row;
+  align-items: baseline;
+  gap: 1rem;
+  padding: 0.5rem 0;
+  border-bottom: 1px solid rgb(var(--gray-light));
+}
+.term-card .name {
+  flex: 0 0 160px;
+  margin: 0;
+  font-weight: 600;
+  color: rgb(var(--black));
+}
+.term-card .definition {
+  margin: 0;
+  color: rgb(var(--gray-dark));
+}
+</style>

--- a/egohygiene.io/src/components/term/TermLayout.astro
+++ b/egohygiene.io/src/components/term/TermLayout.astro
@@ -1,0 +1,24 @@
+---
+import BaseHead from '../BaseHead.astro';
+import Header from '../Header.astro';
+import Footer from '../Footer.astro';
+import type { Term } from '../../../../src/models/Term';
+
+const { term } = Astro.props as { term: Term };
+---
+<!doctype html>
+<html lang="en">
+  <head>
+    <BaseHead title={term.term} description={term.definition.slice(0, 120)} />
+  </head>
+  <body>
+    <Header />
+    <main class="max-w-3xl mx-auto p-4">
+      <article>
+        <h1 class="text-3xl font-bold mb-4">{term.term}</h1>
+        <p class="text-lg text-gray-700">{term.definition}</p>
+      </article>
+    </main>
+    <Footer />
+  </body>
+</html>

--- a/egohygiene.io/src/components/term/TermList.astro
+++ b/egohygiene.io/src/components/term/TermList.astro
@@ -1,0 +1,21 @@
+---
+import type { Term } from '../../../../src/models/Term';
+import TermCard from './TermCard.astro';
+const { terms } = Astro.props as { terms: Term[] };
+---
+<ul class="term-list">
+  {terms.map(t => (
+    <li><TermCard term={t} /></li>
+  ))}
+</ul>
+
+<style>
+.term-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.term-list li {
+  margin: 0;
+}
+</style>

--- a/egohygiene.io/src/pages/terms/[slug].astro
+++ b/egohygiene.io/src/pages/terms/[slug].astro
@@ -1,0 +1,15 @@
+---
+import TermLayout from '../../components/term/TermLayout.astro';
+import { loadTerms, mapTermsBySlug } from '../../../../src/models/Term';
+
+export function getStaticPaths() {
+  return loadTerms().map(t => ({ params: { slug: t.slug } }));
+}
+
+const { slug } = Astro.params;
+const term = mapTermsBySlug()[slug];
+if (!term) {
+  throw new Error(`Term not found: ${slug}`);
+}
+---
+<TermLayout term={term} />

--- a/egohygiene.io/src/pages/terms/index.astro
+++ b/egohygiene.io/src/pages/terms/index.astro
@@ -1,0 +1,24 @@
+---
+import BaseHead from '../../components/BaseHead.astro';
+import Header from '../../components/Header.astro';
+import Footer from '../../components/Footer.astro';
+import { loadTerms } from '../../../../src/models/Term';
+import TermList from '../../components/term/TermList.astro';
+import { SITE_TITLE, SITE_DESCRIPTION } from '../../consts';
+
+const terms = loadTerms();
+---
+<!doctype html>
+<html lang="en">
+  <head>
+    <BaseHead title={`${SITE_TITLE} - Terms`} description={SITE_DESCRIPTION} />
+  </head>
+  <body>
+    <Header />
+    <main class="max-w-3xl mx-auto p-4">
+      <h1 class="text-3xl font-bold mb-4">Terms</h1>
+      <TermList terms={terms} />
+    </main>
+    <Footer />
+  </body>
+</html>

--- a/init-schemas.sh
+++ b/init-schemas.sh
@@ -76,6 +76,22 @@ write_file "$SCHEMA_DIR/synapse.schema.json" '{
 }'
 
 # ------------------------
+# terms.schema.json
+# ------------------------
+write_file "$SCHEMA_DIR/terms.schema.json" '{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Glossary Term",
+  "type": "object",
+  "required": ["id", "slug", "term", "definition"],
+  "properties": {
+    "id": { "type": "string" },
+    "slug": { "type": "string" },
+    "term": { "type": "string" },
+    "definition": { "type": "string" }
+  }
+}'
+
+# ------------------------
 # tags.schema.json
 # ------------------------
 write_file "$SCHEMA_DIR/tags.schema.json" '{
@@ -145,6 +161,7 @@ write_file "$SCHEMA_DIR/manifest.json" '{
   "modules": [
     { "name": "pillars", "file": "pillars.schema.json" },
     { "name": "synapse", "file": "synapse.schema.json" },
+    { "name": "terms", "file": "terms.schema.json" },
     { "name": "tags", "file": "tags.schema.json" },
     { "name": "systems", "file": "systems.schema.json" },
     { "name": "relationships", "file": "relationships.schema.json" }
@@ -160,6 +177,7 @@ write_file "$SCHEMA_DIR/ontology.json" '{
   "entities": [
     { "type": "pillar", "schema": "pillars.schema.json" },
     { "type": "synapse", "schema": "synapse.schema.json" },
+    { "type": "term", "schema": "terms.schema.json" },
     { "type": "tag", "schema": "tags.schema.json" },
     { "type": "system", "schema": "systems.schema.json" }
   ],

--- a/src/data/schemas/manifest.json
+++ b/src/data/schemas/manifest.json
@@ -3,6 +3,7 @@
   "modules": [
     { "name": "pillars", "file": "pillars.schema.json" },
     { "name": "synapse", "file": "synapse.schema.json" },
+    { "name": "terms", "file": "terms.schema.json" },
     { "name": "tags", "file": "tags.schema.json" },
     { "name": "systems", "file": "systems.schema.json" },
     { "name": "relationships", "file": "relationships.schema.json" }

--- a/src/data/schemas/ontology.json
+++ b/src/data/schemas/ontology.json
@@ -4,6 +4,7 @@
   "entities": [
     { "type": "pillar", "schema": "pillars.schema.json" },
     { "type": "synapse", "schema": "synapse.schema.json" },
+    { "type": "term", "schema": "terms.schema.json" },
     { "type": "tag", "schema": "tags.schema.json" },
     { "type": "system", "schema": "systems.schema.json" }
   ],

--- a/src/data/schemas/terms.schema.json
+++ b/src/data/schemas/terms.schema.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Glossary Term",
+  "type": "object",
+  "required": ["id", "slug", "term", "definition"],
+  "properties": {
+    "id": { "type": "string" },
+    "slug": { "type": "string" },
+    "term": { "type": "string" },
+    "definition": { "type": "string" }
+  }
+}

--- a/src/data/terms.json
+++ b/src/data/terms.json
@@ -1,0 +1,20 @@
+[
+  {
+    "id": "1",
+    "slug": "mindfulness",
+    "term": "Mindfulness",
+    "definition": "The quality of being present and fully engaged with whatever we are doing in the moment."
+  },
+  {
+    "id": "2",
+    "slug": "neuroplasticity",
+    "term": "Neuroplasticity",
+    "definition": "The brain's ability to reorganize itself by forming new neural connections throughout life."
+  },
+  {
+    "id": "3",
+    "slug": "somatics",
+    "term": "Somatics",
+    "definition": "Practices that emphasize internal physical perception and experience of the body."
+  }
+]

--- a/src/models/Term.ts
+++ b/src/models/Term.ts
@@ -1,0 +1,29 @@
+import terms from '../data/terms.json';
+
+export interface Term {
+  id: string;
+  slug: string;
+  term: string;
+  definition: string;
+}
+
+export function loadTerms(): Term[] {
+  const data = terms as unknown[];
+  return data.filter((item) => validateTerm(item)) as Term[];
+}
+
+export function mapTermsBySlug(): Record<string, Term> {
+  return loadTerms().reduce((acc, t) => {
+    acc[t.slug] = t;
+    return acc;
+  }, {} as Record<string, Term>);
+}
+
+function validateTerm(item: any): item is Term {
+  if (typeof item !== 'object' || item === null) return false;
+  const required = ['id', 'slug', 'term', 'definition'];
+  for (const key of required) {
+    if (!(key in item)) return false;
+  }
+  return true;
+}


### PR DESCRIPTION
## Summary
- add Term model, schema, and seed data
- include Terms entity in ontology and manifest
- extend schema creation script for terms
- implement Terms pages and components in Astro site
- update header navigation

## Testing
- `pnpm install` *(fails: ERR_PNPM_FETCH_403)*
- `pnpm build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ca517e358832c94fa4036d3e9a02d