### PR TITLE
Introduce component alias

### DIFF
--- a/egohygiene.io/astro.config.mjs
+++ b/egohygiene.io/astro.config.mjs
@@ -16,6 +16,11 @@ export default defineConfig({
   publicDir: path.resolve('./public'),
   trailingSlash: "ignore",
   vite: {
+    resolve: {
+      alias: {
+        '@components': path.resolve('./src/components'),
+      },
+    },
     plugins: [visualizer({
         emitFile: true,
         filename: "stats.html",

--- a/egohygiene.io/src/components/3d/index.ts
+++ b/egohygiene.io/src/components/3d/index.ts
@@ -1,0 +1,5 @@
+export { default as BackgroundAudio } from './BackgroundAudio.jsx';
+export { default as EgoCore } from './EgoCore.jsx';
+export { default as HUDOverlay } from './HUDOverlay.jsx';
+export { default as LandingScene } from './LandingScene.jsx';
+export { default as Planet } from './Planet.jsx';

--- a/egohygiene.io/src/components/Header.astro
+++ b/egohygiene.io/src/components/Header.astro
@@ -1,5 +1,5 @@
 ---
-import HeaderLink from './HeaderLink.astro';
+import { HeaderLink } from '@components';
 import { SITE_TITLE } from '../consts';
 ---
 

--- a/egohygiene.io/src/components/index.ts
+++ b/egohygiene.io/src/components/index.ts
@@ -1,0 +1,10 @@
+export { default as BaseHead } from './BaseHead.astro';
+export { default as Footer } from './Footer.astro';
+export { default as Header } from './Header.astro';
+export { default as HeaderLink } from './HeaderLink.astro';
+export { default as FormattedDate } from './FormattedDate.astro';
+export { default as CategoryCarousel } from './CategoryCarousel.astro';
+export * from './landing';
+export * from './synapse';
+export * from './term';
+export * from './3d';

--- a/egohygiene.io/src/components/landing/LatestSynapses.astro
+++ b/egohygiene.io/src/components/landing/LatestSynapses.astro
@@ -1,6 +1,6 @@
 ---
 import { getSynapses } from '../../../../src/models/Synapse';
-import SynapseCard from '../synapse/SynapseCard.astro';
+import { SynapseCard } from '@components';
 
 const synapses = (await getSynapses())
   .sort((a, b) => new Date(b.created).valueOf() - new Date(a.created).valueOf())

--- a/egohygiene.io/src/components/landing/index.ts
+++ b/egohygiene.io/src/components/landing/index.ts
@@ -1,0 +1,7 @@
+export { default as AboutEgoHygiene } from './AboutEgoHygiene.astro';
+export { default as LandingHero } from './LandingHero.astro';
+export { default as IntroSection } from './IntroSection.astro';
+export { default as LatestSynapses } from './LatestSynapses.astro';
+export { default as ExplorePillars } from './ExplorePillars.astro';
+export { default as LandingPage } from './LandingPage.astro';
+export { default as LandingCategoryCarousel } from './CategoryCarousel.astro';

--- a/egohygiene.io/src/components/synapse/SynapseCard.astro
+++ b/egohygiene.io/src/components/synapse/SynapseCard.astro
@@ -1,5 +1,5 @@
 ---
-import FormattedDate from '../FormattedDate.astro';
+import { FormattedDate } from '@components';
 import type { Synapse } from '../../../../src/models/Synapse';
 
 const { synapse } = Astro.props as { synapse: Synapse };

--- a/egohygiene.io/src/components/synapse/SynapseLayout.astro
+++ b/egohygiene.io/src/components/synapse/SynapseLayout.astro
@@ -1,8 +1,5 @@
 ---
-import BaseHead from '../BaseHead.astro';
-import Header from '../Header.astro';
-import Footer from '../Footer.astro';
-import FormattedDate from '../FormattedDate.astro';
+import { BaseHead, Header, Footer, FormattedDate } from '@components';
 import type { Synapse } from '../../../../src/models/Synapse';
 
 const { synapse } = Astro.props as { synapse: Synapse };

--- a/egohygiene.io/src/components/synapse/SynapseList.astro
+++ b/egohygiene.io/src/components/synapse/SynapseList.astro
@@ -1,6 +1,6 @@
 ---
 import type { Synapse } from '../../../../src/models/Synapse';
-import SynapseCard from './SynapseCard.astro';
+import { SynapseCard } from '@components';
 
 const { synapses } = Astro.props as { synapses: Synapse[] };
 ---

--- a/egohygiene.io/src/components/synapse/index.ts
+++ b/egohygiene.io/src/components/synapse/index.ts
@@ -1,0 +1,4 @@
+export { default as SynapseLayout } from './SynapseLayout.astro';
+export { default as SynapseCard } from './SynapseCard.astro';
+export { default as SynapseList } from './SynapseList.astro';
+export { default as Pagination } from './Pagination.astro';

--- a/egohygiene.io/src/components/term/TermLayout.astro
+++ b/egohygiene.io/src/components/term/TermLayout.astro
@@ -1,7 +1,5 @@
 ---
-import BaseHead from '../BaseHead.astro';
-import Header from '../Header.astro';
-import Footer from '../Footer.astro';
+import { BaseHead, Header, Footer } from '@components';
 import type { Term } from '../../../../src/models/Term';
 
 const { term } = Astro.props as { term: Term };

--- a/egohygiene.io/src/components/term/index.ts
+++ b/egohygiene.io/src/components/term/index.ts
@@ -1,0 +1,3 @@
+export { default as TermLayout } from './TermLayout.astro';
+export { default as TermCard } from './TermCard.astro';
+export { default as TermList } from './TermList.astro';

--- a/egohygiene.io/src/content/blog/using-mdx.mdx
+++ b/egohygiene.io/src/content/blog/using-mdx.mdx
@@ -18,7 +18,7 @@ If you have existing content authored in MDX, this integration will hopefully ma
 Here is how you import and use a UI component inside of MDX.  
 When you open this page in the browser, you should see the clickable button below.
 
-import HeaderLink from '../../components/HeaderLink.astro';
+import { HeaderLink } from '@components';
 
 <HeaderLink href="#" onclick="alert('clicked!')">
 	Embedded component in MDX

--- a/egohygiene.io/src/layouts/BlogPost.astro
+++ b/egohygiene.io/src/layouts/BlogPost.astro
@@ -1,9 +1,6 @@
 ---
 import type { CollectionEntry } from 'astro:content';
-import BaseHead from '../components/BaseHead.astro';
-import Header from '../components/Header.astro';
-import Footer from '../components/Footer.astro';
-import FormattedDate from '../components/FormattedDate.astro';
+import { BaseHead, Header, Footer, FormattedDate } from '@components';
 import { Image } from 'astro:assets';
 
 type Props = CollectionEntry<'blog'>['data'];

--- a/egohygiene.io/src/pages/index.astro
+++ b/egohygiene.io/src/pages/index.astro
@@ -1,12 +1,14 @@
 ---
-import BaseHead from '../components/BaseHead.astro';
-import Header from '../components/Header.astro';
-import LandingScene from '../components/3d/LandingScene.jsx';
+import {
+  BaseHead,
+  Header,
+  LandingScene,
+  AboutEgoHygiene,
+  LatestSynapses,
+  ExplorePillars,
+  Footer,
+} from '@components';
 import { loadPillars } from '../../../src/models/Pillar';
-import AboutEgoHygiene from '../components/landing/AboutEgoHygiene.astro';
-import LatestSynapses from '../components/landing/LatestSynapses.astro';
-import ExplorePillars from '../components/landing/ExplorePillars.astro';
-import Footer from '../components/Footer.astro';
 import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
 ---
 <!doctype html>

--- a/egohygiene.io/src/pages/synapses/[slug].astro
+++ b/egohygiene.io/src/pages/synapses/[slug].astro
@@ -1,5 +1,5 @@
 ---
-import SynapseLayout from '../../components/synapse/SynapseLayout.astro';
+import { SynapseLayout } from '@components';
 import { getSynapses, mapSynapsesBySlug } from '../../../../src/models/Synapse';
 
 export async function getStaticPaths() {

--- a/egohygiene.io/src/pages/synapses/index.astro
+++ b/egohygiene.io/src/pages/synapses/index.astro
@@ -1,12 +1,14 @@
 ---
-import BaseHead from '../../components/BaseHead.astro';
-import Header from '../../components/Header.astro';
-import Footer from '../../components/Footer.astro';
+import {
+  BaseHead,
+  Header,
+  Footer,
+  SynapseList,
+  Pagination,
+  CategoryCarousel,
+} from '@components';
 import { SITE_TITLE, SITE_DESCRIPTION } from '../../consts';
 import { getSynapses } from '../../../../src/models/Synapse';
-import SynapseList from '../../components/synapse/SynapseList.astro';
-import Pagination from '../../components/synapse/Pagination.astro';
-import CategoryCarousel from '../../components/CategoryCarousel.astro';
 import { CATEGORY_GROUPS } from '../../data/categories';
 
 const allSynapses = (await getSynapses()).sort(

--- a/egohygiene.io/src/pages/terms/[slug].astro
+++ b/egohygiene.io/src/pages/terms/[slug].astro
@@ -1,5 +1,5 @@
 ---
-import TermLayout from '../../components/term/TermLayout.astro';
+import { TermLayout } from '@components';
 import { loadTerms, mapTermsBySlug } from '../../../../src/models/Term';
 
 export async function getStaticPaths() {

--- a/egohygiene.io/src/pages/terms/index.astro
+++ b/egohygiene.io/src/pages/terms/index.astro
@@ -1,9 +1,6 @@
 ---
-import BaseHead from '../../components/BaseHead.astro';
-import Header from '../../components/Header.astro';
-import Footer from '../../components/Footer.astro';
+import { BaseHead, Header, Footer, TermList } from '@components';
 import { loadTerms } from '../../../../src/models/Term';
-import TermList from '../../components/term/TermList.astro';
 import { SITE_TITLE, SITE_DESCRIPTION } from '../../consts';
 
 const terms = await loadTerms();

--- a/egohygiene.io/tsconfig.json
+++ b/egohygiene.io/tsconfig.json
@@ -10,6 +10,10 @@
   "compilerOptions": {
     "strictNullChecks": true,
     "jsx": "react-jsx",
-    "jsxImportSource": "react"
+    "jsxImportSource": "react",
+    "baseUrl": ".",
+    "paths": {
+      "@components/*": ["src/components/*"]
+    }
   }
 }


### PR DESCRIPTION
## Summary
- refactor: centralize Astro components with index files
- configure alias `@components` for cleaner imports
- update imports across pages and components

## Testing
- `pnpm install` *(fails: registry access blocked)*
- `pnpm build` *(fails: astro not found due to missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_687cb49c45bc832c9982f7497feeb6b8