### PR TITLE
Add framer motion transitions

### DIFF
--- a/egohygiene.io/src/components/FadeIn.tsx
+++ b/egohygiene.io/src/components/FadeIn.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import { motion } from 'framer-motion';
+
+interface FadeInProps {
+  children: React.ReactNode;
+  className?: string;
+  delay?: number;
+}
+
+export default function FadeIn({ children, className, delay = 0 }: FadeInProps) {
+  return (
+    <motion.div
+      className={className}
+      initial={{ opacity: 0, y: 20 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.3 }}
+      transition={{ duration: 0.6, delay }}
+    >
+      {children}
+    </motion.div>
+  );
+}

--- a/egohygiene.io/src/components/index.ts
+++ b/egohygiene.io/src/components/index.ts
@@ -4,6 +4,7 @@ export { default as Header } from './Header.astro';
 export { default as HeaderLink } from './HeaderLink.astro';
 export { default as FormattedDate } from './FormattedDate.astro';
 export { default as CategoryCarousel } from './CategoryCarousel.astro';
+export { default as FadeIn } from './FadeIn';
 export * from './landing';
 export * from './synapse';
 export * from './term';

--- a/egohygiene.io/src/components/landing/IntroSection.astro
+++ b/egohygiene.io/src/components/landing/IntroSection.astro
@@ -1,25 +1,11 @@
 ---
+import { FadeIn } from '@components';
 ---
-<section id="intro" class="py-16 bg-white dark:bg-gray-900" data-animate>
-  <div class="container mx-auto px-4 max-w-3xl text-center motion-safe:opacity-0 motion-safe:translate-y-6 transition-all duration-700">
+<section id="intro" class="py-16 bg-white dark:bg-gray-900">
+  <FadeIn class="container mx-auto px-4 max-w-3xl text-center" client:visible>
     <h2 class="text-3xl font-semibold text-gray-900 dark:text-gray-100 mb-4">What is Ego Hygiene?</h2>
     <p class="text-gray-700 dark:text-gray-300">
       Ego Hygiene explores mindful practices that harmonize the rational and the mystical. Through reflective technology and spiritual self-care, we nurture clarity, compassion, and creativity.
     </p>
-  </div>
+  </FadeIn>
 </section>
-
-<style>
-#intro[data-visible] .motion-safe\:opacity-0{opacity:1;transform:none;}
-#intro .motion-safe\:opacity-0{opacity:0;transform:translateY(1.5rem);}
-</style>
-
-<script>
-const section = document.getElementById('intro');
-if(section){
-  const obs = new IntersectionObserver((entries)=>{
-    entries.forEach(e=>{if(e.isIntersecting) section.setAttribute('data-visible','');});
-  },{threshold:0.3});
-  obs.observe(section);
-}
-</script>

--- a/egohygiene.io/src/components/landing/LandingHero.astro
+++ b/egohygiene.io/src/components/landing/LandingHero.astro
@@ -1,30 +1,12 @@
 ---
+import { FadeIn } from '@components';
 ---
 <section id="landing-hero" class="min-h-[60vh] flex flex-col justify-center items-center text-center bg-gradient-to-b from-white via-teal-50 to-indigo-100 dark:from-gray-900 dark:via-gray-800 dark:to-gray-900 py-20">
-  <div class="container mx-auto px-4 motion-safe:opacity-0 motion-safe:translate-y-6 transition-all duration-700" data-animate>
+  <FadeIn class="container mx-auto px-4" client:visible>
     <h1 class="text-5xl font-semibold text-gray-900 dark:text-gray-100 mb-4 font-sans">Ego Hygiene</h1>
     <p class="text-lg text-gray-700 dark:text-gray-300 mb-8 max-w-2xl mx-auto">
       Cultivating balance between spiritual insight and technical mastery.
     </p>
     <a href="/synapses" class="inline-block bg-indigo-600 text-white rounded-full px-6 py-3 shadow-lg hover:bg-indigo-700 transition-colors">Explore the Synapses</a>
-  </div>
+  </FadeIn>
 </section>
-
-<style>
-#landing-hero[data-visible] [data-animate]{
-  opacity:1;transform:none;
-}
-#landing-hero [data-animate]{
-  opacity:0;transform:translateY(1.5rem);
-}
-</style>
-
-<script>
-const hero = document.getElementById('landing-hero');
-if(hero){
-  const obs=new IntersectionObserver((e)=>{
-    e.forEach(ent=>{if(ent.isIntersecting){hero.setAttribute('data-visible','');}});
-  },{threshold:0.3});
-  obs.observe(hero);
-}
-</script>

--- a/egohygiene.io/src/components/synapse/SynapseCard.astro
+++ b/egohygiene.io/src/components/synapse/SynapseCard.astro
@@ -1,17 +1,19 @@
 ---
-import { FormattedDate } from '@components';
+import { FormattedDate, FadeIn } from '@components';
 import type { Synapse } from '../../../../src/models/Synapse';
 
 const { synapse } = Astro.props as { synapse: Synapse };
 ---
-<article class="synapse-card">
-  <a href={`/synapses/${synapse.slug}/`} class="block no-underline">
-    <h4 class="title">{synapse.title}</h4>
-    <p class="date"><FormattedDate date={new Date(synapse.created)} /></p>
-    <p class="excerpt">{synapse.content.slice(0, 120)}{synapse.content.length > 120 ? '…' : ''}</p>
-    <p class="tags">{synapse.tags.map(tag => `#${tag}`).join(' ')}</p>
-  </a>
-</article>
+<FadeIn client:visible>
+  <article class="synapse-card">
+    <a href={`/synapses/${synapse.slug}/`} class="block no-underline">
+      <h4 class="title">{synapse.title}</h4>
+      <p class="date"><FormattedDate date={new Date(synapse.created)} /></p>
+      <p class="excerpt">{synapse.content.slice(0, 120)}{synapse.content.length > 120 ? '…' : ''}</p>
+      <p class="tags">{synapse.tags.map(tag => `#${tag}`).join(' ')}</p>
+    </a>
+  </article>
+</FadeIn>
 
 <style>
 .synapse-card {


### PR DESCRIPTION
## Summary
- add reusable `FadeIn` React component
- animate landing hero, intro section and synapse cards

## Testing
- `pnpm build` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_687cb739f3a8832c82709059d6e5cfbc