### PR TITLE
Update synapse schema & seed data

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,14 @@ Structured content is provided through **Astro DB** instead of static JSON files
    pnpm dev
    ```
 
+Before seeding the database, validate the structured content:
+```bash
+pnpm validate-data
+```
+Then run the Astro DB seed command:
+```bash
+pnpm astro db seed
+```
+
 All workspace commands proxy to the `egohygiene.io` package under the hood.
 Run `pnpm astro -- <command>` to invoke any Astro CLI commands.

--- a/egohygiene.io/db/seed.ts
+++ b/egohygiene.io/db/seed.ts
@@ -1,40 +1,62 @@
 import { db } from 'astro:db';
 import { Pillar, Synapse, Tag, Term } from './config';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+async function loadJSON<T>(name: string): Promise<T> {
+  const file = join(process.cwd(), 'src', 'data', name);
+  const data = await readFile(file, 'utf-8');
+  return JSON.parse(data) as T;
+}
 
 // https://astro.build/db/seed
 export default async function seed() {
-  // Placeholder seed data. Real data will be loaded separately.
-  await db.insert(Pillar).values({
-    id: 1,
-    slug: 'demo',
-    title: 'Demo Pillar',
-    subtitle: 'Placeholder',
-    description: 'Seed data placeholder',
-    domains: [],
-    aspects: [],
-    tags: [],
-    quote: 'Seed',
-  });
+  const pillars = await loadJSON<any[]>('pillars.json');
+  for (const p of pillars) {
+    await db.insert(Pillar).values({
+      id: p.id,
+      slug: p.slug,
+      title: p.title,
+      subtitle: p.subtitle,
+      description: p.description,
+      domains: p.domains,
+      aspects: p.aspects,
+      tags: p.tags,
+      quote: p.quote,
+      image: p.image,
+    });
+  }
 
-  await db.insert(Tag).values({
-    name: 'demo',
-    description: 'Placeholder tag',
-  });
+  const tags = await loadJSON<any[]>('tags.json');
+  for (const t of tags) {
+    await db.insert(Tag).values({
+      name: t.name,
+      description: t.description,
+      related: t.related ?? [],
+    });
+  }
 
-  await db.insert(Term).values({
-    id: '1',
-    slug: 'demo-term',
-    term: 'Demo Term',
-    definition: 'Placeholder term definition',
-  });
+  const terms = await loadJSON<any[]>('terms.json');
+  for (const t of terms) {
+    await db.insert(Term).values({
+      id: t.id,
+      slug: t.slug,
+      term: t.term,
+      definition: t.definition,
+    });
+  }
 
-  await db.insert(Synapse).values({
-    id: '1',
-    slug: 'demo-synapse',
-    title: 'Demo Synapse',
-    content: 'Seed data placeholder',
-    tags: ['demo'],
-    pillarSlug: 'demo',
-    created: new Date(),
-  });
+  const synapses = await loadJSON<any[]>('synapses.json');
+  for (const s of synapses) {
+    await db.insert(Synapse).values({
+      id: s.id,
+      slug: s.slug,
+      title: s.title,
+      content: s.content,
+      tags: s.tags,
+      pillarSlug: s.pillarSlug,
+      created: new Date(s.created),
+      updated: s.updated ? new Date(s.updated) : undefined,
+    });
+  }
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,11 @@
     "dev": "pnpm --filter egohygiene.io dev",
     "build": "pnpm --filter egohygiene.io build",
     "preview": "pnpm --filter egohygiene.io preview",
-    "astro": "pnpm --filter egohygiene.io astro"
+    "astro": "pnpm --filter egohygiene.io astro",
+    "validate-data": "ts-node --esm scripts/validate-data.ts"
+  },
+  "devDependencies": {
+    "ajv": "^8.12.0",
+    "ts-node": "^10.9.2"
   }
 }

--- a/scripts/validate-data.ts
+++ b/scripts/validate-data.ts
@@ -1,0 +1,45 @@
+import Ajv from 'ajv';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+const dataDir = join(process.cwd(), 'src', 'data');
+const schemaDir = join(dataDir, 'schemas');
+
+const files = [
+  ['pillars.json', 'pillars.schema.json'],
+  ['synapses.json', 'synapse.schema.json'],
+  ['tags.json', 'tags.schema.json'],
+  ['terms.json', 'terms.schema.json'],
+];
+
+const ajv = new Ajv({ allErrors: true, strict: false });
+
+async function validate() {
+  let valid = true;
+
+  for (const [dataFile, schemaFile] of files) {
+    const schemaPath = join(schemaDir, schemaFile);
+    const dataPath = join(dataDir, dataFile);
+    const schema = JSON.parse(await readFile(schemaPath, 'utf-8'));
+    const data = JSON.parse(await readFile(dataPath, 'utf-8'));
+    const check = ajv.compile(schema);
+    const items = Array.isArray(data) ? data : [data];
+
+    for (const item of items) {
+      const ok = check(item);
+      if (!ok) {
+        valid = false;
+        console.error(`Validation failed for ${dataFile}`, check.errors);
+        break;
+      }
+    }
+  }
+
+  if (valid) {
+    console.log('All data files valid.');
+  } else {
+    process.exitCode = 1;
+  }
+}
+
+validate();

--- a/src/data/schemas/synapse.schema.json
+++ b/src/data/schemas/synapse.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "Synapse Entry",
   "type": "object",
-  "required": ["id", "slug", "title", "content", "tags", "pillar", "created"],
+  "required": ["id", "slug", "title", "content", "tags", "pillarSlug", "created"],
   "properties": {
     "id": { "type": "string" },
     "slug": { "type": "string" },
@@ -12,7 +12,7 @@
       "type": "array",
       "items": { "type": "string" }
     },
-    "pillar": { "type": "string" },
+    "pillarSlug": { "type": "string" },
     "created": { "type": "string", "format": "date-time" },
     "updated": { "type": "string", "format": "date-time" }
   }

--- a/src/data/synapses.json
+++ b/src/data/synapses.json
@@ -4,54 +4,69 @@
     "slug": "gratitude-practice",
     "title": "Gratitude Practice",
     "content": "Write down things you are grateful for.",
-    "tags": ["mindfulness"],
-    "pillar": "self-awareness",
+    "tags": [
+      "mindfulness"
+    ],
     "created": "2024-01-01T00:00:00Z",
-    "updated": "2024-01-02T00:00:00Z"
+    "updated": "2024-01-02T00:00:00Z",
+    "pillarSlug": "self-awareness"
   },
   {
     "id": "2",
     "slug": "morning-stretch",
     "title": "Morning Stretch",
     "content": "Spend five minutes stretching to awaken the body.",
-    "tags": ["movement", "health"],
-    "pillar": "physical-wellbeing",
-    "created": "2024-01-05T00:00:00Z"
+    "tags": [
+      "movement",
+      "health"
+    ],
+    "created": "2024-01-05T00:00:00Z",
+    "pillarSlug": "physical-wellbeing"
   },
   {
     "id": "3",
     "slug": "digital-detox",
     "title": "Digital Detox",
     "content": "Turn off all devices for an hour before bed.",
-    "tags": ["mindfulness", "habits"],
-    "pillar": "self-awareness",
-    "created": "2024-01-07T00:00:00Z"
+    "tags": [
+      "mindfulness",
+      "habits"
+    ],
+    "created": "2024-01-07T00:00:00Z",
+    "pillarSlug": "self-awareness"
   },
   {
     "id": "4",
     "slug": "mindful-breathing",
     "title": "Mindful Breathing",
     "content": "Pause and take ten deep breaths during stressful moments.",
-    "tags": ["meditation"],
-    "pillar": "self-regulation",
-    "created": "2024-01-09T00:00:00Z"
+    "tags": [
+      "meditation"
+    ],
+    "created": "2024-01-09T00:00:00Z",
+    "pillarSlug": "self-regulation"
   },
   {
     "id": "5",
     "slug": "evening-journal",
     "title": "Evening Journal",
     "content": "Reflect on the day by writing a short journal entry.",
-    "tags": ["reflection"],
-    "pillar": "self-awareness",
-    "created": "2024-01-11T00:00:00Z"
+    "tags": [
+      "reflection"
+    ],
+    "created": "2024-01-11T00:00:00Z",
+    "pillarSlug": "self-awareness"
   },
   {
     "id": "6",
     "slug": "walk-in-nature",
     "title": "Walk in Nature",
     "content": "Spend time walking outdoors to clear your mind.",
-    "tags": ["health", "nature"],
-    "pillar": "physical-wellbeing",
-    "created": "2024-01-15T00:00:00Z"
+    "tags": [
+      "health",
+      "nature"
+    ],
+    "created": "2024-01-15T00:00:00Z",
+    "pillarSlug": "physical-wellbeing"
   }
 ]


### PR DESCRIPTION
## Summary
- rename `pillar` to `pillarSlug`
- update seed script to load real data
- add validation script for JSON data
- document how to validate & seed

## Testing
- `pnpm validate-data` *(fails: ts-node not found)*
- `pnpm astro db seed` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d1c8243a8832ca94e67ee382ee884