### PR TITLE
Fix astro db startup error

### DIFF
--- a/egohygiene.io/db/config.ts
+++ b/egohygiene.io/db/config.ts
@@ -8,9 +8,9 @@ export const Pillar = defineTable({
     title: column.text(),
     subtitle: column.text(),
     description: column.text(),
-    domains: column.json<string[]>(),
-    aspects: column.json<string[]>(),
-    tags: column.json<string[]>(),
+    domains: column.json(),
+    aspects: column.json(),
+    tags: column.json(),
     quote: column.text(),
     image: column.text({ optional: true }),
   },
@@ -22,7 +22,7 @@ export const Synapse = defineTable({
     slug: column.text({ unique: true }),
     title: column.text(),
     content: column.text(),
-    tags: column.json<string[]>(),
+    tags: column.json(),
     pillarSlug: column.text(),
     created: column.date(),
     updated: column.date({ optional: true }),
@@ -33,7 +33,7 @@ export const Tag = defineTable({
   columns: {
     name: column.text({ primaryKey: true }),
     description: column.text(),
-    related: column.json<string[]>({ optional: true }),
+    related: column.json({ optional: true }),
   },
 });
 

--- a/egohygiene.io/db/seed.ts
+++ b/egohygiene.io/db/seed.ts
@@ -1,5 +1,5 @@
 import { db } from 'astro:db';
-import { Pillar, Synapse, Tag, Term } from './config';
+import { Pillar, Synapse, Tag, Term } from 'astro:db';
 import { readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 

--- a/egohygiene.io/src/models/Pillar.ts
+++ b/egohygiene.io/src/models/Pillar.ts
@@ -1,5 +1,4 @@
-import { db } from 'astro:db';
-import { Pillar as PillarTable } from '../../egohygiene.io/db/config';
+import { db, Pillar as PillarTable } from 'astro:db';
 
 export interface Pillar {
   id: number;

--- a/egohygiene.io/src/models/Synapse.ts
+++ b/egohygiene.io/src/models/Synapse.ts
@@ -1,5 +1,4 @@
-import { db } from 'astro:db';
-import { Synapse as SynapseTable } from '../../egohygiene.io/db/config';
+import { db, Synapse as SynapseTable } from 'astro:db';
 
 export interface Synapse {
   id: string;

--- a/egohygiene.io/src/models/Tag.ts
+++ b/egohygiene.io/src/models/Tag.ts
@@ -1,5 +1,4 @@
-import { db } from 'astro:db';
-import { Tag as TagTable } from '../../egohygiene.io/db/config';
+import { db, Tag as TagTable } from 'astro:db';
 
 export interface Tag {
   name: string;

--- a/egohygiene.io/src/models/Term.ts
+++ b/egohygiene.io/src/models/Term.ts
@@ -1,5 +1,4 @@
-import { db } from 'astro:db';
-import { Term as TermTable } from '../../egohygiene.io/db/config';
+import { db, Term as TermTable } from 'astro:db';
 
 export interface Term {
   id: string;


### PR DESCRIPTION
## Summary
- remove invalid generics from `column.json()` calls
- import database tables from `astro:db`

## Testing
- `pnpm astro db execute db/seed.ts`
- `pnpm dev`


------
https://chatgpt.com/codex/tasks/task_e_687d27384c24832cb2e2824967c0e6cb