### PR TITLE
Convert 3d React components to TypeScript

### DIFF
--- a/egohygiene.io/src/components/3d/BackgroundAudio.tsx
+++ b/egohygiene.io/src/components/3d/BackgroundAudio.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export default function BackgroundAudio() {
+export default function BackgroundAudio(): React.ReactElement {
   return (
     <audio src="/audio/ambient.mp3" autoPlay loop style={{ display: 'none' }} />
   );

--- a/egohygiene.io/src/components/3d/EgoCore.tsx
+++ b/egohygiene.io/src/components/3d/EgoCore.tsx
@@ -1,9 +1,10 @@
 import React, { useRef } from 'react';
 import { useFrame } from '@react-three/fiber';
 import { useSpring, animated } from '@react-spring/three';
+import type { Mesh } from 'three';
 
-export default function EgoCore() {
-  const mesh: React.RefObject<any> = useRef();
+export default function EgoCore(): React.ReactElement {
+  const mesh = useRef<Mesh>(null);
   const { scale } = useSpring({
     from: { scale: 1 },
     to: { scale: 1.1 },

--- a/egohygiene.io/src/components/3d/HUDOverlay.tsx
+++ b/egohygiene.io/src/components/3d/HUDOverlay.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import type { Pillar } from '@egohygiene/models';
 
-export default function HUDOverlay({ pillars }) {
+export default function HUDOverlay({ pillars }: { pillars: Pillar[] }): React.ReactElement {
   return (
     <>
       <div className="absolute top-4 left-4 text-white text-lg font-semibold">

--- a/egohygiene.io/src/components/3d/LandingScene.tsx
+++ b/egohygiene.io/src/components/3d/LandingScene.tsx
@@ -1,13 +1,13 @@
 import React, { Suspense } from 'react';
 import { Canvas } from '@react-three/fiber';
 import { OrbitControls, Stars, Sparkles } from '@react-three/drei';
-import { animated } from '@react-spring/three';
-import EgoCore from './EgoCore.jsx';
-import Planet from './Planet.jsx';
-import HUDOverlay from './HUDOverlay.jsx';
-import BackgroundAudio from './BackgroundAudio.jsx';
+import EgoCore from './EgoCore.tsx';
+import Planet from './Planet.tsx';
+import HUDOverlay from './HUDOverlay.tsx';
+import BackgroundAudio from './BackgroundAudio.tsx';
+import type { Pillar } from '@egohygiene/models';
 
-export default function LandingScene({ pillars }) {
+export default function LandingScene({ pillars }: { pillars: Pillar[] }): React.ReactElement {
   return (
     <div className="w-screen h-screen relative">
       <Canvas camera={{ position: [0, 0, 10] }}>

--- a/egohygiene.io/src/components/3d/Planet.tsx
+++ b/egohygiene.io/src/components/3d/Planet.tsx
@@ -1,18 +1,19 @@
-import React, { useRef, useState, useMemo } from 'react';
+import React, { useRef, useState } from 'react';
 import { useFrame, useLoader } from '@react-three/fiber';
-import { TextureLoader } from 'three';
+import { TextureLoader, type Group, type Mesh, type Texture } from 'three';
 import { Text, Html } from '@react-three/drei';
 import { useSpring, animated } from '@react-spring/three';
+import type { Pillar } from '@egohygiene/models';
 
 const colors = [
   '#ff6b6b', '#6bfaff', '#ffef6b', '#6bff7a', '#b66bff', '#ff8e6b',
   '#6b91ff', '#ff6bb9', '#6bffde', '#ffd56b', '#9dff6b', '#6bffb9'
 ];
 
-export default function Planet({ pillar, index, total }) {
-  const group = useRef();
-  const mesh = useRef();
-  const [hovered, setHovered] = useState(false);
+export default function Planet({ pillar, index, total }: { pillar: Pillar; index: number; total: number }): React.ReactElement {
+  const group = useRef<Group>(null);
+  const mesh = useRef<Mesh>(null);
+  const [hovered, setHovered] = useState<boolean>(false);
 
   const { scale } = useSpring({ scale: hovered ? 1.5 : 1 });
   const { emissiveIntensity } = useSpring({
@@ -21,9 +22,10 @@ export default function Planet({ pillar, index, total }) {
   });
 
   // Load texture based on slug
-  const texture = useLoader(TextureLoader, `/assets/textures/planets/${pillar.slug}.jpg`);
+  const texture: Texture = useLoader(TextureLoader, `/assets/textures/planets/${pillar.slug}.jpg`);
 
   useFrame(({ clock }) => {
+    if (!group.current || !mesh.current) return;
     const t = clock.getElapsedTime();
     const angle = (index / total) * Math.PI * 2 + t * 0.05;
     const radius = 7;

--- a/egohygiene.io/src/components/3d/index.ts
+++ b/egohygiene.io/src/components/3d/index.ts
@@ -1,5 +1,5 @@
-export { default as BackgroundAudio } from './BackgroundAudio.jsx';
-export { default as EgoCore } from './EgoCore.jsx';
-export { default as HUDOverlay } from './HUDOverlay.jsx';
-export { default as LandingScene } from './LandingScene.jsx';
-export { default as Planet } from './Planet.jsx';
+export { default as BackgroundAudio } from './BackgroundAudio.tsx';
+export { default as EgoCore } from './EgoCore.tsx';
+export { default as HUDOverlay } from './HUDOverlay.tsx';
+export { default as LandingScene } from './LandingScene.tsx';
+export { default as Planet } from './Planet.tsx';


### PR DESCRIPTION
## Summary
- migrate all .jsx files under `src/components/3d` to `.tsx`
- update exports and imports to new extensions
- add explicit return types and prop interfaces for strong typing
- tighten up `Planet` logic to check refs

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module './LandingHero.astro' and other declarations)*

------
https://chatgpt.com/codex/tasks/task_e_687d34effbc0832c9993e003095893cd