### PR TITLE
Fix tsconfig references and add env typings

### DIFF
--- a/egohygiene.io/src/astro-env.d.ts
+++ b/egohygiene.io/src/astro-env.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="astro/client" />

--- a/egohygiene.io/src/astro-shim.d.ts
+++ b/egohygiene.io/src/astro-shim.d.ts
@@ -1,0 +1,37 @@
+declare module '*.astro' {
+  const AstroComponent: any
+  export default AstroComponent
+  export const frontmatter: any
+}
+
+declare module 'astro:db' {
+  export const db: any
+  export const dbUrl: any
+  export const sql: any
+  export function column(...args: any[]): any
+  export function defineDb(...args: any[]): any
+  export function defineTable(...args: any[]): any
+  export function isDbError(...args: any[]): any
+  export const NOW: any
+  export const TRUE: any
+  export const FALSE: any
+  export function eq(...args: any[]): any
+  export function gt(...args: any[]): any
+  export function gte(...args: any[]): any
+  export function lt(...args: any[]): any
+  export function lte(...args: any[]): any
+}
+
+declare module 'astro:content' {
+  export const z: any
+  export function defineCollection(...args: any[]): any
+  export function defineLiveCollection(...args: any[]): any
+}
+
+declare module 'astro:assets' {
+  export const Image: any
+}
+
+declare module 'astro/loaders' {
+  export function glob(...args: any[]): any
+}

--- a/egohygiene.io/src/env.d.ts
+++ b/egohygiene.io/src/env.d.ts
@@ -1,0 +1,3 @@
+/// <reference types="astro/client" />
+/// <reference types="vite/client" />
+/// <reference types="node" />

--- a/egohygiene.io/tsconfig.app.json
+++ b/egohygiene.io/tsconfig.app.json
@@ -11,13 +11,16 @@
       "@egohygiene/*": ["src/*"]
     },
 
+
     // Optional: customize conditions if you're using exports maps
     "customConditions": ["development", "browser", "import"]
   },
   "include": [
     "db",
     "src",
+    "src/env.d.ts",
+    "src/astro-shim.d.ts",
     ".astro/types.d.ts",
-    "astro.config.mts",
+    "astro.config.mts"
   ]
 }

--- a/egohygiene.io/tsconfig.typecheck.json
+++ b/egohygiene.io/tsconfig.typecheck.json
@@ -1,7 +1,16 @@
 {
     "$schema": "https://json.schemastore.org/tsconfig",
-    "extends": "./tsconfig.base.json",
-    "include": ["src", "vite.config.ts", "vitest.config.ts"],
+    "extends": "./tsconfig.app.json",
+    "include": [
+        "db",
+        "src",
+        "src/env.d.ts",
+        "src/astro-shim.d.ts",
+        ".astro/types.d.ts",
+        "astro.config.mts",
+        "vite.config.ts",
+        "vitest.config.ts"
+    ],
     "compilerOptions": {
         "noEmit": true
     }


### PR DESCRIPTION
## Summary
- point typecheck config at tsconfig.app
- include env types in tsconfig
- add env.d.ts with Astro/Vite/Node types
- add shim declarations for Astro specific modules

## Testing
- `pnpm --filter egohygiene.io typecheck` *(fails: module resolution issues)*

------
https://chatgpt.com/codex/tasks/task_e_687d4bf581a8832c9ffcb821aed25e39