### PR TITLE
chore: add lint and format tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ Structured content is provided through **Astro DB** instead of static JSON files
    pnpm dev
    ```
 
+## Quality checks
+
+Run the following commands to maintain code quality:
+
+```bash
+pnpm lint      # run ESLint
+pnpm format    # check Prettier formatting
+pnpm typecheck # verify TypeScript types
+```
+
 Before seeding the database, validate the structured content:
 ```bash
 pnpm validate-data

--- a/egohygiene.io/.prettierrc
+++ b/egohygiene.io/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://json.schemastore.org/prettierrc",
+  "singleQuote": true,
+  "semi": true,
+  "trailingComma": "all"
+}

--- a/egohygiene.io/eslint.config.mjs
+++ b/egohygiene.io/eslint.config.mjs
@@ -1,0 +1,34 @@
+import tsParser from '@typescript-eslint/parser';
+import tsPlugin from '@typescript-eslint/eslint-plugin';
+import reactPlugin from 'eslint-plugin-react';
+import reactHooks from 'eslint-plugin-react-hooks';
+import astroPlugin from 'eslint-plugin-astro';
+import prettier from 'eslint-config-prettier';
+
+export default [
+  { ignores: ['node_modules'] },
+  ...astroPlugin.configs['flat/recommended'],
+  {
+    files: ['**/*.{ts,tsx,astro}'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        project: './tsconfig.eslint.json',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+      react: reactPlugin,
+      'react-hooks': reactHooks,
+    },
+    settings: {
+      react: { version: 'detect' },
+    },
+    rules: {
+      ...tsPlugin.configs.recommended.rules,
+      ...reactPlugin.configs.recommended.rules,
+      ...reactHooks.configs.recommended.rules,
+    },
+  },
+  prettier,
+];

--- a/egohygiene.io/package.json
+++ b/egohygiene.io/package.json
@@ -42,7 +42,9 @@
     "types": "tsc -p tsconfig.types.json",
     "build-cli": "tsc -p tsconfig.build.json",
     "typedoc": "typedoc --options config/typedoc.json",
-    "dev:db:seed": "tsx src/db/seed.ts"
+    "dev:db:seed": "tsx src/db/seed.ts",
+    "lint": "eslint .",
+    "format": "prettier . --check"
   },
   "dependencies": {
     "@astrojs/db": "^0.15.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "preview": "pnpm --filter egohygiene.io preview",
     "astro": "pnpm --filter egohygiene.io astro",
     "typecheck": "pnpm --filter egohygiene.io typecheck",
-    "validate-data": "ts-node --esm scripts/validate-data.ts"
+    "validate-data": "ts-node --esm scripts/validate-data.ts",
+    "lint": "pnpm --filter egohygiene.io lint",
+    "format": "pnpm --filter egohygiene.io format"
   },
   "devDependencies": {
     "@types/node": "^24.0.15",


### PR DESCRIPTION
## Summary
- set up project-wide ESLint flat config
- configure Prettier and expose lint/format scripts
- document quality checks in README

## Testing
- `pnpm format` *(fails: Code style issues found in 46 files. Run Prettier with --write to fix.)*
- `pnpm lint` *(fails: Parsing errors and no-explicit-any issues)*
- `pnpm typecheck` *(fails: 42 TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_688d9daef0d4832c8fbbe5bc749c05ae